### PR TITLE
Link typo fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   </a>
 </p>
 
-## [About](https://docs.spacebar.com/client/)
+## [About](https://docs.spacebar.chat/setup/clients/)
 
 This is the open source, discord-compatible, native client.
 


### PR DESCRIPTION
"https://docs.spacebar.com/client" doesn't exists. Replaced it with "https://docs.spacebar.chat/setup/clients/", which points to this same repository.