### PR TITLE
Updated react-secure-storage to 1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
 		"react-moment": "^1.1.3",
 		"react-router-dom": "^6.11.1",
 		"react-scripts": "5.0.1",
-		"react-secure-storage": "^1.2.2",
+		"react-secure-storage": "^1.3.0",
 		"react-select-search": "^4.1.6",
 		"react-spinners": "^0.13.8",
 		"reoverlay": "^1.0.3",


### PR DESCRIPTION
In this version of react-secure-storage, we have patched a bug, where in react and NextJs, the .env values are bind on the build time and dynamic access of env values like 

let REACT_SECURE_KEY ="@.secure" and process.env[REACT_SECURE_KEY] will give a null value. 

This has been patched on version 1.3.0.