### PR TITLE
remove invalid input

### DIFF
--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -47,4 +47,3 @@ jobs:
           includeDebug: true
           includeRelease: true
           includeUpdaterJson: true
-          buildIdAsVersion: true


### PR DESCRIPTION
`buildIdAsVersion` is not a valid input anymore in the latest version of `spacebarchat/tauri-action@dev` (https://github.com/spacebarchat/tauri-action/blob/dev/action.yml).