### PR TITLE
Hide @everyone role in User Popout

### DIFF
--- a/src/components/floating/UserProfilePopout.tsx
+++ b/src/components/floating/UserProfilePopout.tsx
@@ -273,9 +273,9 @@ function UserProfilePopout({ user, member }: Props) {
 
 				{member && (
 					<Section>
-						<Heading>{member.roles.length ? "Roles" : "No Roles"}</Heading>
+						<Heading>{member.displayRoles.length ? "Roles" : "No Roles"}</Heading>
 						<RoleList>
-							{member.roles.map((x, i) => (
+							{member.displayRoles.map((x, i) => (
 								<RolePill key={i}>
 									<RolePillDot color={x.color} />
 									<RoleName>{x.name}</RoleName>

--- a/src/stores/objects/GuildMember.ts
+++ b/src/stores/objects/GuildMember.ts
@@ -48,6 +48,11 @@ export default class GuildMember {
 	}
 
 	@computed
+	get displayRoles() {
+		return this.roles.filter((role) => role.id !== this.guild.id);
+	}
+
+	@computed
 	get roleColor() {
 		const highestRole = this.roles.reduce((prev, role) => {
 			if (role.position > prev.position) return role;


### PR DESCRIPTION
## What changed?

- Add `@computed` property: `GuildMember.displayRoles`
    - Filters out the @everyone role
    
Resolves: https://github.com/spacebarchat/server/issues/1213

## How was this tested?

| Before | After |
| :-: | :-: |
| ![image](https://github.com/user-attachments/assets/14dbd6c6-0b72-41f4-933b-a26a26a511d3) | ![image](https://github.com/user-attachments/assets/6bb2eb47-ee0d-4a32-a75c-3632a3cff1d3) |
