### PR TITLE
Add instance picker to Registration page

### DIFF
--- a/src/hooks/useInstanceValidation.ts
+++ b/src/hooks/useInstanceValidation.ts
@@ -1,0 +1,69 @@
+import useLogger from "@hooks/useLogger";
+import { Globals, REST, RouteSettings } from "@utils";
+import React, { useEffect } from "react";
+import { FieldPath, FieldValues, UseFormClearErrors, UseFormSetError } from "react-hook-form";
+
+const getValidURL = (url: string) => {
+	try {
+		return new URL(url);
+	} catch (e) {
+		return undefined;
+	}
+};
+
+export function useInstanceValidation<T extends FieldValues>(
+	setError: UseFormSetError<T>,
+	clearErrors: UseFormClearErrors<T>,
+	instanceField: FieldPath<T> = "instance" as FieldPath<T>,
+) {
+	const logger = useLogger("InstanceValidation");
+	const [debounce, setDebounce] = React.useState<NodeJS.Timeout | null>(null);
+	const [isCheckingInstance, setCheckingInstance] = React.useState(false);
+
+	const handleInstanceChange = React.useCallback(
+		(e: React.ChangeEvent<HTMLInputElement>) => {
+			clearErrors(instanceField);
+			setCheckingInstance(false);
+
+			// Clear existing debounce
+			if (debounce) clearTimeout(debounce);
+
+			const doRequest = async () => {
+				const url = getValidURL(e.target.value);
+				if (!url) return;
+				setCheckingInstance(true);
+
+				let endpoints: RouteSettings;
+				try {
+					endpoints = await REST.getEndpointsFromDomain(url);
+				} catch (e) {
+					setCheckingInstance(false);
+					return setError(instanceField, {
+						type: "manual",
+						message: (e instanceof Error && e.message) || "Instance could not be resolved",
+					} as any);
+				}
+
+				logger.debug(`Instance lookup has set routes to`, endpoints);
+				Globals.routeSettings = endpoints;
+				Globals.save();
+				setCheckingInstance(false);
+			};
+
+			setDebounce(setTimeout(doRequest, 500));
+		},
+		[debounce, setError, clearErrors, instanceField, logger],
+	);
+
+	// Cleanup debounce on unmount
+	useEffect(() => {
+		return () => {
+			if (debounce) clearTimeout(debounce);
+		};
+	}, [debounce]);
+
+	return {
+		handleInstanceChange,
+		isCheckingInstance,
+	};
+}

--- a/src/pages/RegistrationPage.tsx
+++ b/src/pages/RegistrationPage.tsx
@@ -1,3 +1,4 @@
+import { useInstanceValidation } from "@/hooks/useInstanceValidation";
 import SpacebarLogoBlue from "@assets/images/logo/Logo-Blue.svg?react";
 import {
 	AuthContainer,
@@ -16,8 +17,8 @@ import {
 	SubmitButton,
 	Wrapper,
 } from "@components/AuthComponents";
-import DOBInput from "@components/DOBInput";
 import { TextDivider } from "@components/Divider";
+import DOBInput from "@components/DOBInput";
 import HCaptcha from "@components/HCaptcha";
 import HCaptchaLib from "@hcaptcha/react-hcaptcha";
 import { useAppStore } from "@hooks/useAppStore";
@@ -25,6 +26,7 @@ import useLogger from "@hooks/useLogger";
 import { Routes } from "@spacebarchat/spacebar-api-types/v9";
 import { AUTH_NO_BRANDING } from "@stores/AppStore";
 import {
+	Globals,
 	IAPILoginResponseSuccess,
 	IAPIRegisterRequest,
 	IAPIRegisterResponseError,
@@ -35,6 +37,7 @@ import { useForm } from "react-hook-form";
 import { useNavigate } from "react-router-dom";
 
 type FormValues = {
+	instance: string;
 	email: string;
 	username: string;
 	password: string;
@@ -70,6 +73,12 @@ function RegistrationPage() {
 		setValue("captcha_key", undefined);
 	};
 
+	const { handleInstanceChange, isCheckingInstance } = useInstanceValidation<FormValues>(
+		setError,
+		clearErrors,
+		"instance",
+	);
+
 	const onSubmit = handleSubmit((data) => {
 		if (errors.date_of_birth) return;
 
@@ -77,9 +86,11 @@ function RegistrationPage() {
 		setCaptchaSiteKey(undefined);
 		setValue("captcha_key", undefined);
 
+		const { instance, ...rest } = data;
+
 		app.rest
 			.post<IAPIRegisterRequest, IAPILoginResponseSuccess>(Routes.register(), {
-				...data,
+				...rest,
 				consent: true,
 			})
 			.then((r) => {
@@ -179,6 +190,40 @@ function RegistrationPage() {
 				)}
 
 				<FormContainer onSubmit={onSubmit}>
+					<InputContainer marginBottom={true} style={{ marginTop: 0 }}>
+						<LabelWrapper error={!!errors.instance}>
+							<InputLabel>Instance</InputLabel>
+							{isCheckingInstance != false && (
+								<InputErrorText>
+									<>
+										<TextDivider>-</TextDivider>
+										Checking
+									</>
+								</InputErrorText>
+							)}
+							{errors.instance && (
+								<InputErrorText>
+									<>
+										<TextDivider>-</TextDivider>
+										{errors.instance.message}
+									</>
+								</InputErrorText>
+							)}
+						</LabelWrapper>
+						<InputWrapper>
+							<Input
+								type="url"
+								{...register("instance", {
+									required: true,
+									value: Globals.routeSettings.wellknown,
+								})}
+								placeholder="Instance Root URL"
+								onChange={handleInstanceChange}
+								error={!!errors.instance}
+								disabled={loading}
+							/>
+						</InputWrapper>
+					</InputContainer>
 					<InputContainer marginBottom={true} style={{ marginTop: 0 }}>
 						<LabelWrapper error={!!errors.email}>
 							<InputLabel>Email</InputLabel>


### PR DESCRIPTION
## What changed?

- Add instance picker to registration page
- Extract instance picker shared logic into hook
- Use hook in Login/Registration pages

See also: #144
Resolves: #321

## How was this tested?

I created an account and logged in through two different instances.

Creating an account works as expected, login continues to function.

| Before | After |
| :-: | :-: |
| ![image](https://github.com/user-attachments/assets/36338cef-11b0-4989-b036-c0c54b085f6b) | ![image](https://github.com/user-attachments/assets/c9ccbace-ba0a-4e30-bc4d-d99e275aa49d) |